### PR TITLE
Improved shell.nix 

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -4,5 +4,6 @@ pkgs.mkShell {
   nativeBuildInputs = with pkgs; [
     gnumake util-linux
     xorg.libX11 xorg.libXext xorg.libXft
+    clang-tools bear
   ];
 }


### PR DESCRIPTION
Added `bear` and `clang-tools` to `./shell.nix` for better developing experience.

`bear` is dependency for `make dev`.
`clang-tools` provides `clangd`, which can be used by helix editor